### PR TITLE
chore(commitlint): do not lint commit generated by @semantic-release/…

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,6 @@
+/* eslint-env node */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  // HACK for "@semantic-release/git" generating too long commit message
+  ignores: [(message) => /\[skip ci\]/.test(message)],
+}

--- a/package.json
+++ b/package.json
@@ -77,11 +77,6 @@
     "semi": false,
     "singleQuote": true
   },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
-  },
   "lint-staged": {
     "*.{js,jsx,vue,ts,tsx}": "eslint --fix",
     "*.{css,scss,vue}": "stylelint --fix",


### PR DESCRIPTION
…git bot

@semantic-release/git generate commit with more than 100 character body
length, which breaks the ci flow.

This quick fix prevents commitlint from linting commit which message
includes `[skip ci]`.